### PR TITLE
Fix gcc warnings.

### DIFF
--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -748,7 +748,7 @@ static const DNSMessage_t xDefaultPartDNSHeader =
 
 		/* Fill in the byte count, then move the pucStart pointer up to
 		the found byte position. */
-		*pucStart = ( uint8_t ) ( ( uint32_t ) pucByte - ( uint32_t ) pucStart );
+		*pucStart = ( uint8_t ) ( ( uint64_t ) pucByte - ( uint64_t ) pucStart );
 		( *pucStart )--;
 
 		pucStart = pucByte;
@@ -763,7 +763,7 @@ static const DNSMessage_t xDefaultPartDNSHeader =
 
 	/* Return the total size of the generated message, which is the space from
 	the last written byte to the beginning of the buffer. */
-	return ( ( uint32_t ) pucByte - ( uint32_t ) pucUDPPayloadBuffer + 1 ) + sizeof( *pxTail );
+	return ( ( uint64_t ) pucByte - ( uint64_t ) pucUDPPayloadBuffer + 1 ) + sizeof( *pxTail );
 }
 /*-----------------------------------------------------------*/
 

--- a/FreeRTOS_TCP_WIN.c
+++ b/FreeRTOS_TCP_WIN.c
@@ -1277,7 +1277,7 @@ const int32_t l500ms = 500;
 	{
 	TCPSegment_t *pxSegment;
 	uint32_t ulMaxTime;
-	uint32_t ulReturn  = ~0UL;
+	uint32_t ulReturn  = ~0U;
 
 
 		/* Fetches data to be sent-out now.


### PR DESCRIPTION
Fix gcc warnings in FreeRTOS TCP stack.  
*** These changes are untested! ***

I'm hesitant to merge these until we can test.
Change to usGeneratedChecksum seems most dangerous.

FreeRTOS_DNS.c:
    Typecasting assumed 32 bit pointers. Change to 64.
FreeRTOS_IP.c:
    Typecasting assumed 32 bit pointers. Change to 64.
    usGeneratedChecksum(): ulAlignBits becomes 64 bit.
    Disabled warnings about address of field in packed struct.
FreeRTOS_WIN.c
    Initialization assumed 32 bit int was a Long.
    
